### PR TITLE
Azot modifications - breakpoint and updated failure message

### DIFF
--- a/src/com/sap/azot/AzotConfig.java
+++ b/src/com/sap/azot/AzotConfig.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2013 Anthony MÜLLER.
+ * Copyright (C) 2013 Anthony MÃœLLER.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -37,6 +37,8 @@ public final class AzotConfig {
 	
 	public boolean ANALYZE = false;
 	
+	public String BREAKPOINT = null;
+	
 	public File OUTPUT_DIRECTORY = null;
 	
 	public String JMX = null;
@@ -51,6 +53,7 @@ public final class AzotConfig {
 			DUMP = toBoolean(azotProperties, "azot-dump", false);
 			REPORT = toBoolean(azotProperties, "azot-report", false);
 			ANALYZE = toBoolean(azotProperties, "azot-analyze", false);
+			BREAKPOINT = toString(azotProperties, "azot-breakpoint", null);
 			
 			OUTPUT_DIRECTORY = toFile(azotProperties, "azot-output-directory", ".");
 			JMX = toString(azotProperties, "azot-jmx", null);

--- a/src/com/sap/azot/WorkflowEngine.java
+++ b/src/com/sap/azot/WorkflowEngine.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2013 Anthony MÜLLER.
+ * Copyright (C) 2013 Anthony MÃœLLER.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -141,7 +141,17 @@ public class WorkflowEngine {
 				println("==========================================================================================");
 
 
-				if (AzotConfig.GLOBAL.INTERACTIVE) {
+				// check breakpoints definition (separated by a semicolon)
+				boolean breakpointFound = true;
+				if (AzotConfig.GLOBAL.BREAKPOINT != null) {
+					breakpointFound = false;
+					String[] breakpoints = AzotConfig.GLOBAL.BREAKPOINT.split(";");
+					for (String breakpoint : breakpoints) {
+						breakpointFound |= breakpoint.equals(call.getName());
+					}
+				}
+
+				if (AzotConfig.GLOBAL.INTERACTIVE && breakpointFound) {
 					Scanner sc = new Scanner(System.in);
 					echo("Press 'Enter' to continue... (type 'off' to turn off the interactive mode)");
 					String what = sc.nextLine();
@@ -473,7 +483,10 @@ public class WorkflowEngine {
 
 		
 		// Raw data of response
-		if (response != null && response.getRaw() != null) {
+		if (response != null) {
+			if (response.getRaw() == null) {
+				response.setRaw(new RawResponse());
+			}
 			final RawResponse rawResponse = response.getRaw();
 			rawResponse.setCode(connection.getResponseCode());
 			rawResponse.setStatus(connection.getHeaderField(null));
@@ -662,7 +675,9 @@ public class WorkflowEngine {
 				if (actual != null && !actual.equals(expected)) {
 					callReport.setStatus(Status.FAILURE);
 					callReport.setType("com.sap.azot.AssertionFailedError");
-					callReport.setFailureMessage("Assert failure: expected='" + expected + "' actual='" + actual + "'");
+					callReport.setFailureMessage("Assert failure: expected='" + expected + "' actual='" + actual + "'\n" +
+							"Original values: expected='" + responseAssert.getExpected() + "' actual='" + responseAssert.getActual() + "'\n" +
+									"Response content: " + response.getRaw().getContent().getValue());
 					break;
 				}
 			}


### PR DESCRIPTION
Here is some modifications to :
- add a breakpoint to the interactive mode. with 'azot-breakpoint' property, you can ask to stop the script execution at a particular call (based on its name).
- retrieve more information in the failure message. It contains the original expected and actual value, and the complete response content
